### PR TITLE
add default from parameter to truffle.js

### DIFF
--- a/truffle.js
+++ b/truffle.js
@@ -3,7 +3,8 @@ module.exports = {
     development: {
       host: "localhost",
       port: 8545,
-      network_id: "*" // Match any network id
+      network_id: "*", // Match any network id
+      from: "0x0000000000000000000000000000000000000001"
     }
   }
 };


### PR DESCRIPTION
resolve `parameter 'from' not passed to function` error by adding default `from` parameter to `truffle.js`. fix: https://github.com/trufflesuite/truffle/issues/548