### PR TITLE
Update tests for web3 1.0

### DIFF
--- a/contracts/ConvertLib.sol
+++ b/contracts/ConvertLib.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.5.0;
 
 library ConvertLib{
-	function convert(uint amount,uint conversionRate) public returns (uint convertedAmount)
+	function convert(uint amount,uint conversionRate) public pure returns (uint convertedAmount)
 	{
 		return amount * conversionRate;
 	}

--- a/contracts/ConvertLib.sol
+++ b/contracts/ConvertLib.sol
@@ -1,7 +1,7 @@
-pragma solidity ^0.4.4;
+pragma solidity ^0.5.0;
 
 library ConvertLib{
-	function convert(uint amount,uint conversionRate) returns (uint convertedAmount)
+	function convert(uint amount,uint conversionRate) public returns (uint convertedAmount)
 	{
 		return amount * conversionRate;
 	}

--- a/contracts/MetaCoin.sol
+++ b/contracts/MetaCoin.sol
@@ -24,11 +24,11 @@ contract MetaCoin {
 		return true;
 	}
 
-	function getBalanceInEth(address addr) public returns(uint){
+	function getBalanceInEth(address addr) public view returns(uint){
 		return ConvertLib.convert(getBalance(addr),2);
 	}
 
-	function getBalance(address addr) public returns(uint) {
+	function getBalance(address addr) public view returns(uint) {
 		return balances[addr];
 	}
 }

--- a/contracts/MetaCoin.sol
+++ b/contracts/MetaCoin.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.4;
+pragma solidity ^0.5.0;
 
 import "./ConvertLib.sol";
 
@@ -12,23 +12,23 @@ contract MetaCoin {
 
 	event Transfer(address indexed _from, address indexed _to, uint256 _value);
 
-	function MetaCoin() {
+	constructor() public {
 		balances[tx.origin] = 10000;
 	}
 
-	function sendCoin(address receiver, uint amount) returns(bool sufficient) {
+	function sendCoin(address receiver, uint amount) public returns(bool sufficient) {
 		if (balances[msg.sender] < amount) return false;
 		balances[msg.sender] -= amount;
 		balances[receiver] += amount;
-		Transfer(msg.sender, receiver, amount);
+		emit Transfer(msg.sender, receiver, amount);
 		return true;
 	}
 
-	function getBalanceInEth(address addr) returns(uint){
+	function getBalanceInEth(address addr) public returns(uint){
 		return ConvertLib.convert(getBalance(addr),2);
 	}
 
-	function getBalance(address addr) returns(uint) {
+	function getBalance(address addr) public returns(uint) {
 		return balances[addr];
 	}
 }

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.4;
+pragma solidity ^0.5.0;
 
 contract Migrations {
   address public owner;
@@ -8,15 +8,15 @@ contract Migrations {
     if (msg.sender == owner) _;
   }
 
-  function Migrations() {
+  constructor() public {
     owner = msg.sender;
   }
 
-  function setCompleted(uint completed) restricted {
+  function setCompleted(uint completed) public restricted {
     last_completed_migration = completed;
   }
 
-  function upgrade(address new_address) restricted {
+  function upgrade(address new_address) public restricted {
     Migrations upgraded = Migrations(new_address);
     upgraded.setCompleted(last_completed_migration);
   }

--- a/test/TestMetacoin.sol
+++ b/test/TestMetacoin.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.2;
+pragma solidity ^0.5.0;
 
 import "truffle/Assert.sol";
 import "truffle/DeployedAddresses.sol";
@@ -6,7 +6,7 @@ import "../contracts/MetaCoin.sol";
 
 contract TestMetacoin {
 
-  function testInitialBalanceUsingDeployedContract() {
+  function testInitialBalanceUsingDeployedContract() public {
     MetaCoin meta = MetaCoin(DeployedAddresses.MetaCoin());
 
     uint expected = 10000;
@@ -14,7 +14,7 @@ contract TestMetacoin {
     Assert.equal(meta.getBalance(tx.origin), expected, "Owner should have 10000 MetaCoin initially");
   }
 
-  function testInitialBalanceWithNewMetaCoin() {
+  function testInitialBalanceWithNewMetaCoin() public {
     MetaCoin meta = new MetaCoin();
 
     uint expected = 10000;

--- a/test/metacoin.js
+++ b/test/metacoin.js
@@ -17,10 +17,10 @@ contract('MetaCoin', function(accounts) {
       meta = instance;
       return meta.getBalance.call(accounts[0]);
     }).then(function(outCoinBalance) {
-      metaCoinBalance = outCoinBalance.toNumber();
+      metaCoinBalance = parseInt(outCoinBalance);
       return meta.getBalanceInEth.call(accounts[0]);
     }).then(function(outCoinBalanceEth) {
-      metaCoinEthBalance = outCoinBalanceEth.toNumber();
+      metaCoinEthBalance = parseInt(outCoinBalanceEth);
     }).then(function() {
       assert.equal(metaCoinEthBalance, 2 * metaCoinBalance, "Library function returned unexpected function, linkage may be broken");
     });
@@ -43,18 +43,18 @@ contract('MetaCoin', function(accounts) {
       meta = instance;
       return meta.getBalance.call(account_one);
     }).then(function(balance) {
-      account_one_starting_balance = balance.toNumber();
+      account_one_starting_balance = parseInt(balance);
       return meta.getBalance.call(account_two);
     }).then(function(balance) {
-      account_two_starting_balance = balance.toNumber();
+      account_two_starting_balance = parseInt(balance);
       return meta.sendCoin(account_two, amount, {from: account_one});
     }).then(function() {
       return meta.getBalance.call(account_one);
     }).then(function(balance) {
-      account_one_ending_balance = balance.toNumber();
+      account_one_ending_balance = parseInt(balance);
       return meta.getBalance.call(account_two);
     }).then(function(balance) {
-      account_two_ending_balance = balance.toNumber();
+      account_two_ending_balance = parseInt(balance);
 
       assert.equal(account_one_ending_balance, account_one_starting_balance - amount, "Amount wasn't correctly taken from the sender");
       assert.equal(account_two_ending_balance, account_two_starting_balance + amount, "Amount wasn't correctly sent to the receiver");

--- a/truffle.js
+++ b/truffle.js
@@ -3,7 +3,18 @@ module.exports = {
     development: {
       host: "localhost",
       port: 8545,
-      network_id: "*" // Match any network id
+      network_id: "*", // Match any network id
+      gas: 5000000
+    }
+  },
+  compilers: {
+    solc: {
+      settings: {
+        optimizer: {
+          enabled: true, // Default: false
+          runs: 200      // Default: 200
+        },
+      }
     }
   }
 };


### PR DESCRIPTION
Modifies tests to use `parseInt` instead of BigNumber methods. Web3 1.0 now returns these values as strings.