### PR TITLE
Remove readme from the ignore portion of the config

### DIFF
--- a/truffle-init.json
+++ b/truffle-init.json
@@ -1,7 +1,6 @@
 {
   "docs_url": "http://truffleframework.com/docs",
   "ignore": [
-    "README.md",
     ".gitignore"
   ],
   "commands": {


### PR DESCRIPTION
Including README.md in the ignore section of the config causes it to be deleted at the end of unboxing/initing.